### PR TITLE
lircd.conf for Cambridge Audio RC-CXA61/CXA81/CXC/CXN V2

### DIFF
--- a/LIRC-Remote/cambridge-cx-remote.lircd.conf
+++ b/LIRC-Remote/cambridge-cx-remote.lircd.conf
@@ -23,7 +23,9 @@ begin remote
       begin codes
 
           KEY_MUTE                 0x1C0D
-          KEY_BRIGHTNESS           0x0647
+          KEY_BRIGHTNESS_0         0x0647
+          KEY_BRIGHTNESS_1         0x1653
+          KEY_BRIGHTNESS_2         0x1652
           POWEROFF                 0x164F
           POWERON                  0x1E4E
 

--- a/LIRC-Remote/cambridge-cx-remote.lircd.conf
+++ b/LIRC-Remote/cambridge-cx-remote.lircd.conf
@@ -1,0 +1,63 @@
+begin remote
+
+  name  cambridge_cx_remote
+  bits           13
+  flags RC5|CONST_LENGTH
+  eps            30
+  aeps          100
+
+  one           924   843
+  zero          924   843
+  plead         937
+  gap          112929
+  toggle_bit_mask 0x0
+  frequency    38000
+
+      begin codes
+
+          KEY_MUTE                 0x1C0D
+          KEY_BRIGHTNESS           0x0647
+          POWEROFF                 0x164F
+          POWERON                  0x1E4E
+
+          # CXA PART ( YELLOW )
+          SOURCE_A1                0x0424
+          SOURCE_A2                0x0C25
+          SOURCE_A3                0x0426
+          SOURCE_A4                0x0C27
+          SOURCE_USB               0x0432
+          SOURCE_BLUETOOTH         0x0C33
+          SOURCE_D1                0x0429
+          SOURCE_D2                0x0C2A
+          SOURCE_D3                0x042B
+          SOURCE_MP3               0x0C2C
+
+          # CXN PART ( GREEN )
+          KEY_REPEAT               0x1E15
+          KEY_SHUFFLE              0x1614
+          KEY_THREE_DOTS           0x1E09
+          KEY_DIGITAL_IN           0x0638
+          KEY_BACK                 0x1616
+          KEY_HOME                 0x1E0C
+          KEY_INFO                 0x161C
+          KEY_TOGGLE               0x1618
+          KEY_NEXT                 0x1619
+          KEY_PREVIOUS             0x1E17
+          KEY_VOLUMEUP             0x1C10
+          KEY_VOLUMEDOWN           0x1C11
+          KEY_ENTER                0x1611
+          KEY_UP                   0x160D
+          KEY_DOWN                 0x1E13
+          KEY_RIGHT                0x1612
+          KEY_LEFT                 0x1E10
+          KEY_1                    0x1E39
+          KEY_2                    0x163A
+          KEY_3                    0x1E3B
+          KEY_4                    0x163C
+          KEY_5                    0x1E3D
+          KEY_6                    0x163E
+          KEY_7                    0x1E3F
+          KEY_8                    0x0600
+      end codes
+
+end remote

--- a/LIRC-Remote/cambridge-cx-remote.lircd.conf
+++ b/LIRC-Remote/cambridge-cx-remote.lircd.conf
@@ -3,15 +3,22 @@ begin remote
   name  cambridge_cx_remote
   bits           13
   flags RC5|CONST_LENGTH
-  eps            30
-  aeps          100
+  eps            20
+  aeps            0
 
-  one           924   843
-  zero          924   843
-  plead         937
-  gap          112929
-  toggle_bit_mask 0x0
-  frequency    38000
+  header          0     0
+  one           889  889
+  zero          889  889
+  plead         889
+  ptrail          0
+  foot            0     0
+  repeat          0     0
+  pre             0     0
+  post            0     0
+  gap          113792
+  toggle_bit      2
+  frequency    36000
+  duty_cycle   50
 
       begin codes
 


### PR DESCRIPTION
I've spotted that your lircd.conf ( probably modified https://sourceforge.net/p/lirc-remotes/code/ci/master/tree/remotes/cambridge_audio/X40A.lircd.conf ) is lacking a lot of keys from actual CXA81 remote ( RC-CXA61/CXA81/CXC/CXN V2 ).

Here is my lircd.conf created from scratch which has all buttons from yellow CXA and green CXN parts of remote.

Hope it'll save somebody's time ;)

